### PR TITLE
feat: implement dereferencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ const schema = {
   format: 'date-time',
 };
 
-const convertedSchema = toOpenApi(schema);
+(async () => {
+  const convertedSchema = await toOpenApi(schema);
+  console.log(convertedSchema);
+})();
 
-console.log(convertedSchema);
 ```
 
 The example prints out
@@ -44,8 +46,6 @@ The example prints out
 }
 ```
 
-**NOTE**: `$ref`s are not dereferenced. Use a dereferencer such as [json-schema-ref-parser](https://www.npmjs.com/package/json-schema-ref-parser) prior to using this package.
-
 ### Options
 
 The function accepts `options` object as the second argument.
@@ -54,6 +54,9 @@ The function accepts `options` object as the second argument.
 
 If set to `false`, converts the provided schema in place. If `true`, clones the schema by converting it to JSON and back. The overhead of the cloning is usually negligible. Defaults to `true`.
 
+#### `dereference` (boolean)
+
+If set to `true`, all local and remote references (http/https and file) $refs will be dereferenced. Defaults to `false`.
 
 ## Why?
 

--- a/package.json
+++ b/package.json
@@ -10,13 +10,21 @@
   "repository": "github:openapi-js/json-schema-to-openapi-schema",
   "author": "Phil Sturgeon <me@philsturgeon.uk>",
   "license": "MIT",
+  "engines": {
+    "node": ">=8"
+  },
   "devDependencies": {
     "coveralls": "^3.0.0",
     "mocha": "^5.0.0",
+    "nock": "^11.3.6",
     "nyc": "^11.6.0",
     "should": "^13.2.0"
   },
   "dependencies": {
-    "@cloudflare/json-schema-walker": "^0.1.1"
+    "@cloudflare/json-schema-walker": "^0.1.1",
+    "@stoplight/json-ref-resolver": "^2.3.0",
+    "@stoplight/yaml": "^3.3.1",
+    "node-fetch": "^2.6.0",
+    "tslib": "^1.10.0"
   }
 }

--- a/test/array-items.test.js
+++ b/test/array-items.test.js
@@ -3,13 +3,13 @@
 const convert = require('../');
 const should = require('should');
 
-it('array-items', () => {
+it('array-items', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'array',
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'array',

--- a/test/clone_schema.test.js
+++ b/test/clone_schema.test.js
@@ -3,13 +3,13 @@
 const convert = require('../');
 const should = require('should');
 
-it('cloning schema by default', () => {
+it('cloning schema by default', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: ['string', 'null'],
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'string',
@@ -20,13 +20,13 @@ it('cloning schema by default', () => {
 	should(result).not.deepEqual(schema, 'the schema was modified in place');
 });
 
-it('cloning schema with cloneSchema option', () => {
+it('cloning schema with cloneSchema option', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: ['string', 'null'],
 	};
 
-	const result = convert(schema, { cloneSchema: true });
+	const result = await convert(schema, { cloneSchema: true });
 
 	const expected = {
 		type: 'string',
@@ -37,13 +37,13 @@ it('cloning schema with cloneSchema option', () => {
 	should(result).not.deepEqual(schema, 'the schema was modified in place');
 });
 
-it('direct schema modification', () => {
+it('direct schema modification', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: ['string', 'null'],
 	};
 
-	const result = convert(schema, { cloneSchema: false });
+	const result = await convert(schema, { cloneSchema: false });
 
 	const expected = {
 		type: 'string',

--- a/test/combination_keywords.test.js
+++ b/test/combination_keywords.test.js
@@ -3,7 +3,7 @@
 const convert = require('../');
 const should = require('should');
 
-it('iterates allOfs and converts types', () => {
+it('iterates allOfs and converts types', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		allOf: [
@@ -28,7 +28,7 @@ it('iterates allOfs and converts types', () => {
 		]
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		allOf: [
@@ -56,7 +56,7 @@ it('iterates allOfs and converts types', () => {
 	should(result).deepEqual(expected, 'iterated allOfs');
 });
 
-it('iterates anyOfs and converts types', () => {
+it('iterates anyOfs and converts types', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		anyOf: [
@@ -86,7 +86,7 @@ it('iterates anyOfs and converts types', () => {
 		]
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		anyOf: [
@@ -119,7 +119,7 @@ it('iterates anyOfs and converts types', () => {
 	should(result).deepEqual(expected, 'anyOfs iterated');
 });
 
-it('iterates oneOfs and converts types', () => {
+it('iterates oneOfs and converts types', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		oneOf: [
@@ -147,7 +147,7 @@ it('iterates oneOfs and converts types', () => {
 		]
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		oneOf: [
@@ -180,7 +180,7 @@ it('iterates oneOfs and converts types', () => {
 	should(result).deepEqual(expected, 'oneOfs iterated');
 });
 
-it('converts types in not', () => {
+it('converts types in not', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'object',
@@ -192,7 +192,7 @@ it('converts types in not', () => {
 		}
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'object',
@@ -209,7 +209,7 @@ it('converts types in not', () => {
 });
 
 
-it('nested combination keywords', () => {
+it('nested combination keywords', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		anyOf: [
@@ -250,7 +250,7 @@ it('nested combination keywords', () => {
 		]
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		anyOf: [

--- a/test/complex_schemas.test.js
+++ b/test/complex_schemas.test.js
@@ -5,17 +5,17 @@ const should = require('should');
 const getSchema = require('./helpers').getSchema;
 
 ['basic', 'address', 'calendar'].forEach(test => {
-	it(`converts ${test}/openapi.json`, () => {
+	it(`converts ${test}/openapi.json`, async () => {
 		const schema = getSchema(test + '/json-schema.json');
-		const result = convert(schema);
+		const result = await convert(schema);
 		const expected = getSchema(test + '/openapi.json');
 
 		should(result).deepEqual(expected, 'converted');
 	});
 
-	it(`converting ${test}/openapi.json in place`, () => {
+	it(`converting ${test}/openapi.json in place`, async () => {
 		const schema = getSchema(test + '/json-schema.json');
-		const result = convert(schema, { cloneSchema: false });
+		const result = await convert(schema, { cloneSchema: false });
 		const expected = getSchema(test + '/openapi.json');
 
 		should(schema).deepEqual(result, 'changed schema in place');

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -3,14 +3,14 @@
 const convert = require('../');
 const should = require('should');
 
-it('const', () => {
+it('const', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'string',
 		const: 'hello'
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'string',

--- a/test/dereference_schema.test.js
+++ b/test/dereference_schema.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const convert = require('../');
+const should = require('should');
+const nock = require('nock');
+const { join } = require('path');
+
+it('not dereferencing schema by default', async () => {
+  const schema = {
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    foo: {
+      $ref: '#/definitions/foo',
+    },
+    definitions: {
+      foo: ['string', 'null'],
+    },
+  };
+
+  const result = await convert(JSON.parse(JSON.stringify(schema)));
+
+  const expected = { ...schema };
+  delete expected.$schema;
+
+  should(result).deepEqual(expected, 'result does not match the expected');
+});
+
+it('dereferencing schema with deference option', async () => {
+  const schema = {
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    type: {
+      $ref: '#/definitions/foo',
+    },
+    definitions: {
+      foo: ['string', 'null'],
+    },
+  };
+
+  const result = await convert(schema, { dereference: true });
+
+  const expected = {
+    type: 'string',
+    nullable: true,
+    definitions: {
+      foo: ['string', 'null'],
+    },
+  };
+
+  should(result).deepEqual(expected, 'result does not match the expected');
+});
+
+it('dereferencing schema with remote http and https references', async () => {
+  nock('http://foo.bar/')
+    .get('/schema.yaml')
+    .replyWithFile(200, join(__dirname, 'fixtures/definitions.yaml'), {
+      'Content-Type': 'application/yaml',
+    });
+
+  nock('https://baz.foo/')
+    .get('/schema.yaml')
+    .replyWithFile(200, join(__dirname, 'fixtures/definitions.yaml'), {
+      'Content-Type': 'application/yaml',
+    });
+
+  const schema = {
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    allOf: [
+      { $ref: 'http://foo.bar/schema.yaml#/definitions/foo' },
+      { $ref: 'https://baz.foo/schema.yaml#/definitions/bar' },
+    ],
+  };
+
+  const result = await convert(schema, { dereference: true });
+
+  const expected = {
+    allOf: [
+      { type: 'string' },
+      { type: 'number' },
+    ],
+  };
+
+  should(result).deepEqual(expected, 'result does not match the expected');
+});
+
+it('dereferencing schema with file references', async () => {
+  const schema = {
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    allOf: [
+      // points to current working directory, hence the `test` prefix
+      { $ref: './test/fixtures/definitions.yaml#/definitions/foo' },
+      { $ref: join(__dirname, 'fixtures/definitions.yaml#/definitions/bar') },
+    ],
+  };
+
+  const result = await convert(schema, { dereference: true });
+
+  const expected = {
+    allOf: [
+      { type: 'string' },
+      { type: 'number' },
+    ],
+  };
+
+  should(result).deepEqual(expected, 'result does not match the expected');
+});

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -3,7 +3,7 @@
 const convert = require('../');
 const should = require('should');
 
-it('uses the first example from a schema', () => {
+it('uses the first example from a schema', async () => {
   const schema = {
     $schema: 'http://json-schema.org/draft-06/schema#',
     examples: [
@@ -12,7 +12,7 @@ it('uses the first example from a schema', () => {
     ]
   };
 
-  const result = convert(schema);
+  const result = await convert(schema);
 
   should(result).deepEqual({
     example: 'foo',

--- a/test/exclusiveMinMax.test.js
+++ b/test/exclusiveMinMax.test.js
@@ -3,7 +3,7 @@
 const convert = require('../');
 const should = require('should');
 
-it('exclusiveMinMax', () => {
+it('exclusiveMinMax', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'integer',
@@ -11,7 +11,7 @@ it('exclusiveMinMax', () => {
 		exclusiveMinimum: 0
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'integer',

--- a/test/fixtures/definitions.yaml
+++ b/test/fixtures/definitions.yaml
@@ -1,0 +1,5 @@
+definitions:
+  foo:
+    type: "string"
+  bar:
+    type: "number"

--- a/test/if-then-else.test.js
+++ b/test/if-then-else.test.js
@@ -3,7 +3,7 @@
 const convert = require('../');
 const should = require('should');
 
-it('if-then-else', () => {
+it('if-then-else', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		if: { type: 'object' },
@@ -11,7 +11,7 @@ it('if-then-else', () => {
                 else: { format: 'uuid' }
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		oneOf: [

--- a/test/invalid_types.test.js
+++ b/test/invalid_types.test.js
@@ -6,16 +6,16 @@ const getSchema = require('./helpers').getSchema;
 
 it('dateTime is invalid type', () => {
 	const schema = { type: 'dateTime' };
-	should.throws(() => { convert(schema); }, /InvalidTypeError/);
+	return should(convert(schema)).rejectedWith({ name: 'InvalidTypeError' });
 });
 
 
 it('foo is invalid type', () => {
 	const schema = { type: 'foo' };
-	should.throws(() => { convert(schema); }, /InvalidTypeError/);
+	return should(convert(schema)).rejectedWith({ name: 'InvalidTypeError' });
 });
 
 it('invalid type inside complex schema', () => {
 	const schema = getSchema('invalid/json-schema.json');
-	should.throws(() => { convert(schema); }, /InvalidTypeError.*invalidtype/);
+	return should(convert(schema)).rejectedWith({ name: 'InvalidTypeError' });
 });

--- a/test/items.test.js
+++ b/test/items.test.js
@@ -3,7 +3,7 @@
 const convert = require('../');
 const should = require('should');
 
-it('items', () => {
+it('items', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'array',
@@ -14,7 +14,7 @@ it('items', () => {
 		}
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'array',

--- a/test/nullable.test.js
+++ b/test/nullable.test.js
@@ -3,13 +3,13 @@
 const convert = require('../');
 const should = require('should');
 
-it('adds `nullable: true` for `type: [string, null]`', () => {
+it('adds `nullable: true` for `type: [string, null]`', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: ['string', 'null'],
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	should(result).deepEqual({
 		type: 'string',
@@ -18,7 +18,7 @@ it('adds `nullable: true` for `type: [string, null]`', () => {
 });
 
 
-it('supports nullables inside sub-schemas', () => {
+it('supports nullables inside sub-schemas', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		oneOf: [
@@ -27,7 +27,7 @@ it('supports nullables inside sub-schemas', () => {
 		]
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	should(result).deepEqual({
 		oneOf: [
@@ -37,13 +37,13 @@ it('supports nullables inside sub-schemas', () => {
 	});
 });
 
-it('does not add nullable for non null types', () => {
+it('does not add nullable for non null types', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'string'
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	should(result).deepEqual({
 		type: 'string'

--- a/test/pattern_properties.test.js
+++ b/test/pattern_properties.test.js
@@ -3,7 +3,7 @@
 const convert = require('../');
 const should = require('should');
 
-it('renames patternProperties to x-patternProperties', () => {
+it('renames patternProperties to x-patternProperties', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'object',
@@ -17,7 +17,7 @@ it('renames patternProperties to x-patternProperties', () => {
 		}
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'object',

--- a/test/properties.test.js
+++ b/test/properties.test.js
@@ -3,13 +3,13 @@
 const convert = require('../');
 const should = require('should');
 
-it('type array', () => {
+it('type array', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: ['string', 'null']
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'string',
@@ -19,7 +19,7 @@ it('type array', () => {
 	should(result).deepEqual(expected);
 });
 
-it('properties', () => {
+it('properties', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'object',
@@ -34,7 +34,7 @@ it('properties', () => {
 		}
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'object',
@@ -53,7 +53,7 @@ it('properties', () => {
 	should(result).deepEqual(expected);
 });
 
-it('addionalProperties is false', () => {
+it('addionalProperties is false', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'object',
@@ -65,7 +65,7 @@ it('addionalProperties is false', () => {
 		additionalProperties: false
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'object',
@@ -80,7 +80,7 @@ it('addionalProperties is false', () => {
 	should(result).deepEqual(expected, 'properties converted');
 });
 
-it('addionalProperties is true', () => {
+it('addionalProperties is true', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'object',
@@ -92,7 +92,7 @@ it('addionalProperties is true', () => {
 		additionalProperties: true
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'object',
@@ -107,7 +107,7 @@ it('addionalProperties is true', () => {
 	should(result).deepEqual(expected);
 });
 
-it('addionalProperties is an object', () => {
+it('addionalProperties is an object', async () => {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'object',
@@ -127,7 +127,7 @@ it('addionalProperties is an object', () => {
 		}
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'object',

--- a/test/readonly_writeonly.test.js
+++ b/test/readonly_writeonly.test.js
@@ -3,7 +3,7 @@
 const convert = require('../');
 const should = require('should');
 
-it('maintain readOnly and writeOnly props', () => {
+it('maintain readOnly and writeOnly props', async () => {
 	const schema = {
 		type: 'object',
 		properties: {
@@ -18,7 +18,7 @@ it('maintain readOnly and writeOnly props', () => {
 		}
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'object',
@@ -37,7 +37,7 @@ it('maintain readOnly and writeOnly props', () => {
 	should(result).deepEqual(expected);
 });
 
-it('deep schema', () => {
+it('deep schema', async () => {
 	const schema = {
 		type: 'object',
 		required: ['prop1', 'prop2'],
@@ -72,7 +72,7 @@ it('deep schema', () => {
 		}
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	const expected = {
 		type: 'object',

--- a/test/subschema.test.js
+++ b/test/subschema.test.js
@@ -3,7 +3,7 @@
 const convert = require('../');
 const should = require('should');
 
-it('strips $id from all subschemas not just root`', () => {
+it('strips $id from all subschemas not just root`', async () => {
 	const schema = {
     $id: "https://foo/bla",
     $schema: "http://json-schema.org/draft-06/schema#",
@@ -26,7 +26,7 @@ it('strips $id from all subschemas not just root`', () => {
     }
 	};
 
-	const result = convert(schema);
+	const result = await convert(schema);
 
 	should(result).deepEqual({
     type: "object",


### PR DESCRIPTION
Closes https://github.com/openapi-js/json-schema-to-openapi-schema/issues/2

Decided to make `convert` async to keep everything more consistent, even though I didn't necessarily need to, as I could return a promise for `dereference: true` case, or a value otherwise.
`dereference` is false by default, but happy to change it.